### PR TITLE
U03012026

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -25,7 +25,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -42,13 +42,13 @@ jobs:
         run: cd demo && npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './demo/dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -119,6 +119,36 @@ Use the build script to compile the Rust code to WASM and bundle the TypeScript 
 ./scripts/build.sh
 ```
 
+### Running the Demo
+
+The demo application is located in the `demo/` folder and uses Vite for development and building:
+
+```bash
+# Navigate to demo directory
+cd demo
+
+# Install dependencies (includes Vite and links local chroma-detect package)
+npm install
+
+# Start development server (runs on http://localhost:3000)
+npm run dev
+
+# Build for production
+npm run build
+
+# Preview production build
+npm run preview
+```
+
+The demo demonstrates:
+
+- Interactive video upload and chromakey detection
+- Real-time configuration of detection parameters
+- Visual display of detected colors and metrics
+- Test runner for validating detection accuracy
+
+See [demo/README.md](demo/README.md) for more details about the demo and test runner.
+
 ### Running Tests
 
 ```bash


### PR DESCRIPTION
Fix: Update GitHub Actions workflow to use latest versions

- Update actions/upload-pages-artifact from v2 to v3
- Update actions/setup-node from v3 to v4  
- Update actions/configure-pages from v3 to v5
- Update actions/deploy-pages from v2 to v4
- Update actions/checkout from v3 to v4

This resolves the deprecated action version error in CI/CD.